### PR TITLE
Porting to scikit-learn 1.5.0

### DIFF
--- a/skclean/handlers/example_weighting.py
+++ b/skclean/handlers/example_weighting.py
@@ -124,7 +124,7 @@ class WeightedBagging(BaggingClassifier):
                  verbose=0):
         BaggingClassifier.__init__(
             self,
-            base_estimator=classifier,
+            estimator=classifier,
             warm_start=False,
             n_estimators=n_estimators,
             n_jobs=n_jobs,
@@ -224,7 +224,7 @@ class Costing(BaggingClassifier):
                  verbose=0):
         BaggingClassifier.__init__(
             self,
-            base_estimator=classifier,
+            estimator=classifier,
             n_estimators=n_estimators,
             warm_start=False,
             n_jobs=n_jobs,

--- a/skclean/pipeline.py
+++ b/skclean/pipeline.py
@@ -15,8 +15,8 @@ composite estimator, as a chain of transforms, samples and estimators.
 
 from sklearn import pipeline as skpipeline
 from sklearn.base import clone
-from sklearn.utils import _print_elapsed_time
-from sklearn.utils.metaestimators import if_delegate_has_method
+from sklearn.utils._user_interface import _print_elapsed_time
+from sklearn.utils.metaestimators import available_if
 from sklearn.utils.validation import check_memory
 
 __all__ = ["Pipeline", "make_pipeline"]
@@ -214,7 +214,13 @@ class Pipeline(skpipeline.Pipeline):
             else:
                 return last_step.fit(Xt, yt, **fit_params_last).transform(Xt)
 
-    @if_delegate_has_method(delegate="_final_estimator")
+    def _estimator_has(attr):
+        def check(self):
+            return hasattr(self.estimator, attr)
+
+        return check
+    
+    @available_if(_estimator_has("_final_estimator"))
     def fit_predict(self, X, y=None, **fit_params):
         """Apply `fit_predict` of last step in pipeline after transforms.
 


### PR DESCRIPTION
When I updated to scikit-learn 1.5.0, scikit-clean was not longer portable. Made some small changes to fix this.